### PR TITLE
Feature: adicionada doc swagger automatica

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Também é necessário renomear o arquivo `.env-sample` para `.env` e incluir as
 
 Para verificar se está funcionando, basta acessar a url [http://localhost:3000/](http://localhost:3000/)
 
+### Acesso à Documentação do Swagger
+
+Para acessar a documentação do Swagger, acessar a url [http://localhost:3000/api-docs/](http://localhost:3000/api-docs/)
 
 # Arquitetura e estrutura de pastas
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,10 @@
       "devDependencies": {
         "@types/express": "^4.17.21",
         "@types/node": "^20.14.9",
+        "@types/swagger-ui-express": "^4.1.6",
         "nodemon": "^3.1.4",
+        "swagger-autogen": "^2.23.7",
+        "swagger-ui-express": "^5.0.1",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^1.1.6",
         "typescript": "^5.5.2"
@@ -191,6 +194,16 @@
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+      "integrity": "sha512-UVSiGYXa5IzdJJG3hrc86e8KdZWLYxyEsVoUI4iPXc7CO4VZ3AfNP8d/8+hrDRIqz+HAaSMtZSqAsF3Nq2X/Dg==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
@@ -439,6 +452,15 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/define-data-property": {
@@ -916,6 +938,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -1468,6 +1502,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-autogen": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.7.tgz",
+      "integrity": "sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/swagger-autogen/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw==",
+      "dev": true
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "dev": true,
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node dist/index.js",
     "build": "tsc",
     "serve": "node dist/app.js",
-    "start:dev": "npm install --save-dev; CHOKIDAR_USEPOLLING=true dotenv -- tsnd --transpile-only --respawn --ignore-watch node_modules src/app.ts"
+    "start:dev": "npm install --save-dev; CHOKIDAR_USEPOLLING=true dotenv -- tsnd --transpile-only --respawn --ignore-watch node_modules src/app.ts",
+    "start-gendoc": "node src/swagger.ts"
   },
   "keywords": [],
   "author": "",
@@ -21,7 +22,10 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.9",
+    "@types/swagger-ui-express": "^4.1.6",
     "nodemon": "^3.1.4",
+    "swagger-autogen": "^2.23.7",
+    "swagger-ui-express": "^5.0.1",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^1.1.6",
     "typescript": "^5.5.2"

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,6 @@
 import express from 'express';
+import swaggerUi from "swagger-ui-express";
+import swaggerOutput from "./swagger-output.json";
 import { ListaGenericaEndpoint } from './easyorder/Infrastructure/Input/Endpoint/Exemplo/ListaGenericaEndpoint';
 import { CadastrarClienteEndpoint } from './easyorder/Infrastructure/Input/Endpoint/Cliente/CadastrarClienteEndpoint';
 import { RemoverProdutoEndpoint } from './easyorder/Infrastructure/Input/Endpoint/Produto/RemoverProdutoEndpoint';
@@ -8,12 +10,16 @@ const port = 3000;
 
 app.use(express.json());
 
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerOutput));
+
 app.get('/', (req, res) => {
   res.send('Olá, mundo com Express e TypeScript!');
 });
 
 app.get('/exemplo/lista-generica', ListaGenericaEndpoint.handle);
+
 app.post('/cliente/cadastrar', CadastrarClienteEndpoint.handle);
+
 app.delete('/produto/remover', RemoverProdutoEndpoint.handle);
 
 app.listen(port, () => {

--- a/src/easyorder/Infrastructure/Input/Endpoint/Cliente/CadastrarClienteEndpoint.ts
+++ b/src/easyorder/Infrastructure/Input/Endpoint/Cliente/CadastrarClienteEndpoint.ts
@@ -1,11 +1,15 @@
 import express from "express";
-
 import { CadastrarClienteUsecase } from '../../../../Core/Application/Usecase/Clientes/CadastrarClienteUsecase';
 import { ClienteRepositoryMock } from '../../../Output/Repository/ClienteRepositoryMock';
 
 export class CadastrarClienteEndpoint {
 
     public static async handle(req: express.Request, res: express.Response): Promise<void> {
+
+        /**
+            #swagger.summary = 'Cadastrar novo cliente'
+            #swagger.description = 'Endpoint para cadastro de novo cliente para posterior identificação em pedidos e uso em campanhas de marketing'
+        */
 
         const usecase = new CadastrarClienteUsecase(
             new ClienteRepositoryMock()

--- a/src/swagger-output.json
+++ b/src/swagger-output.json
@@ -1,0 +1,99 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "easyOrder 1.0",
+    "description": "Sistema de Gestão de Pedidos - Tech Challenge Pos Tech SOAT",
+    "version": "1.0.0"
+  },
+  "host": "localhost:3000",
+  "basePath": "/",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/exemplo/lista-generica": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/cliente/cadastrar": {
+      "post": {
+        "summary": "Cadastrar novo cliente",
+        "description": "Endpoint para cadastro de novo cliente para posterior identificação em pedidos e uso em campanhas de marketing",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "cpf": {
+                  "example": "any"
+                },
+                "nome": {
+                  "example": "any"
+                },
+                "email": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Solicitação Inválida"
+          }
+        }
+      }
+    },
+    "/produto/remover": {
+      "delete": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Não Encontrado"
+          },
+          "500": {
+            "description": "Erro Interno do Servidor"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,0 +1,17 @@
+const swaggerAutogen = require('swagger-autogen')({ language: 'pt-BR' });
+
+const doc = {
+  info: {
+    title: 'easyOrder 1.0',
+    description: 'Sistema de Gestão de Pedidos - Tech Challenge Pos Tech SOAT',
+  },
+  host: 'localhost:3000'
+};
+
+const outputFile = './swagger-output.json';
+const routes = ['./app.ts'];
+
+/* NOTE: If you are using the express Router, you must pass in the 'routes' only the 
+root file where the route starts, such as index.js, app.js, routes.js, etc ... */
+
+swaggerAutogen(outputFile, routes, doc);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Adicionado modulo de documentação de swagger automático em typescript https://swagger-autogen.github.io/docs/

- Módulos necessários adicionados: npm install swagger-autogen swagger-ui-express @types/swagger-ui-express
- Criação de swagger.ts que direciona arquivo de rotas e informações básicas do projeto
- Ajuste de package.json com adição do comando em script: 'start-gendoc' para geração da documentação no swagger-output.json
- Alterações no app.ts para inicialização da rota /api-docs
- Ajuste em CadastrarClienteEndpoint como exemplo inicial de título e descrição
- Alteração de parametro de compilação typescript necessário para importação direta de json pela lib
- Adição da explicação da rota no Readme.md

Testes
- Atualização da documentação através do comando npm run start-gendoc
- Acesso ao endpoint do SwaggerUI em http://localhost:3000/api-docs/